### PR TITLE
Fix ID field name in flight creation response

### DIFF
--- a/Pages/Flight/Create.cshtml.cs
+++ b/Pages/Flight/Create.cshtml.cs
@@ -29,7 +29,9 @@ public class CreateModel : PageModel
                 return BadRequest("La validación falló.");
 
             var plannerID = await repo.SaveFlightPlanAsync(Flight);
-            return new JsonResult(new { success = true, id = plannerID });
+            // The front-end expects the identifier in a property named "ID".
+            // Use the same casing here to avoid mismatches.
+            return new JsonResult(new { success = true, ID = plannerID });
         }
         catch (ApplicationException aex)
         {


### PR DESCRIPTION
## Summary
- return `ID` instead of `id` when saving a flight plan

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68410c86f0d8832a8ddf50a24c4b95c4