### PR TITLE
Fix Docker build and update docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 bin
 obj
-**/*.ts
 node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,20 @@ ENV ASPNETCORE_URLS=http://+:80
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 
-# Copia el archivo del proyecto y restaura
-COPY ["FlightPlanner.csproj", "./"]
+# Instala Node.js para compilar TypeScript
+RUN apt-get update && \
+    apt-get install -y nodejs npm && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copia los archivos de NPM y restaura paquetes
+COPY package*.json ./
+RUN npm ci
+
+# Copia el archivo del proyecto y restaura paquetes de .NET
+COPY FlightPlanner.csproj ./
 RUN dotnet restore
 
-# Copia todo el contenido del proyecto
+# Copia el resto del código fuente
 COPY . .
 
 # Publica la app

--- a/README.md
+++ b/README.md
@@ -1,24 +1,20 @@
 # FlightPlanner Docker Setup
 
-This project can be built and run using Docker. A `docker-compose.yml` file is provided that starts the application and a PostgreSQL database.
+This project can be built and run using Docker. Ensure you provide a PostgreSQL
+connection string in the `ConnectionStrings__DefaultConnection` environment
+variable when running the container.
 
 ## Building the image
 
 ```bash
-docker compose build
+docker build -t flightplanner .
 ```
 
-## Running the stack
+## Running the container
 
 ```bash
-docker compose up
+docker run -e ConnectionStrings__DefaultConnection="<connection string>" -p 8080:80 flightplanner
 ```
 
-The application will be available at [http://localhost:8080](http://localhost:8080).
-
-Database data is stored in a named volume `db-data`.
-
-The database connection string is provided via the
-`ConnectionStrings__DefaultConnection` environment variable in
-`docker-compose.yml`. The application now reads this value so that it can
-successfully connect to the PostgreSQL container when running with Docker.
+The application will then be available at
+[http://localhost:8080](http://localhost:8080).


### PR DESCRIPTION
## Summary
- install Node and npm during Docker build
- copy package files for npm install
- remove `.ts` ignore from `.dockerignore`
- update README with instructions for `docker build` and `docker run`

## Testing
- `npm run build`
- `dotnet build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68479f3f7b24832ab29f8fdd3f733b94